### PR TITLE
Fixing separated READ_ID entries

### DIFF
--- a/bam_comparison/bam_util_to_csv.py
+++ b/bam_comparison/bam_util_to_csv.py
@@ -12,22 +12,25 @@ class Entry:
         self.read = read
 
     def set_v1(self, v1):
-        if self.v1:
-            print("Read %s has at least two reads for v1: %s" % (read, self.v1))
-            sys.exit(1)
         if not v1.isdigit():
-            print("Read %s v1 not numeric: %s" % (read, v1))
+            print("Read %s v1 not numeric: %s" % (self.read, v1))
             sys.exit(1)
-        self.v1 = int(v1)
+        int_v1 = int(v1)
+        if self.v1 and int_v1 != self.v1:
+            print("Read %s has more than two reads for v2 with different scores: first - %s, update - %s" % (self.read, self.v1, int_v1))
+            sys.exit(1)
+        self.v1 = int_v1
 
     def set_v2(self, v2):
-        if self.v2:
-            print("Read %s has at least two reads for v2: %s" % (read, self.v2))
-            sys.exit(1)
         if not v2.isdigit():
-            print("Read %s v2 not numeric: %s" % (read, v2))
+            print("Read %s v2 not numeric: %s" % (self.read, v2))
             sys.exit(1)
-        self.v2 = int(v2)
+        int_v2 = int(v2)
+        if self.v2 and int_v2 != self.v2:
+            print("Read %s has more than two reads for v2 with different scores: first - %s, update - %s" % (self.read, self.v2, int_v2))
+            sys.exit(1)
+        self.v2 = int_v2
+
     def is_complete(self):
         return self.v2 != None and self.v1 != None
     def to_string(self):
@@ -70,6 +73,7 @@ def parse_entries(bam_util_output):
                 entry = entry_map[curr_read_id]
             else:
                 entry = Entry(curr_read_id)
+                entry_map[curr_read_id] = entry
         else:
             score = line.split()[-1]
             if lead_char == "<":

--- a/bam_comparison/bam_util_to_csv.py
+++ b/bam_comparison/bam_util_to_csv.py
@@ -3,6 +3,9 @@
 import sys
 import os
 USAGE="python bam_util_to_csv.py /PATH/TO/bam_util_output"
+
+ERRORS = []
+
 class Entry:
     read = None
     v1 = None
@@ -17,8 +20,8 @@ class Entry:
             sys.exit(1)
         int_v1 = int(v1)
         if self.v1 and int_v1 != self.v1:
-            print("Read %s has more than two reads for v2 with different scores: first - %s, update - %s" % (self.read, self.v1, int_v1))
-            sys.exit(1)
+            err = "Read %s has more than two reads for v2 with different scores: first - %s, update - %s" % (self.read, self.v1, int_v1)
+            ERRORS.append(err)
         self.v1 = int_v1
 
     def set_v2(self, v2):
@@ -27,8 +30,8 @@ class Entry:
             sys.exit(1)
         int_v2 = int(v2)
         if self.v2 and int_v2 != self.v2:
-            print("Read %s has more than two reads for v2 with different scores: first - %s, update - %s" % (self.read, self.v2, int_v2))
-            sys.exit(1)
+            err = "Read %s has more than two reads for v2 with different scores: first - %s, update - %s" % (self.read, self.v2, int_v2)
+            ERRORS.append(err)
         self.v2 = int_v2
 
     def is_complete(self):
@@ -76,6 +79,7 @@ def parse_entries(bam_util_output):
                 entry_map[curr_read_id] = entry
         else:
             score = line.split()[-1]
+            flag = line.split()[1]
             if lead_char == "<":
                 entry.set_v1(score)
             elif lead_char == ">":
@@ -117,6 +121,8 @@ def main():
     entries = parse_entries(bam_util_output)
     print("WRITING %s" % output_file)
     write_file(output_file, entries)
+    print("ERRORS")
+    print("\n".join(ERRORS))
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
**Description**: The `bam diff` output doesn't output all entries for a READ ID at once. This previously caused a READ ID to not be paired when its "partner entry" existed later in the file (example below). This change 

_bam diff output_
```
K00121:54:HC373BBXX:4:1115:7811:9754
>       b1      1:8143070       68S30M2S        0
...
K00121:54:HC373BBXX:4:1115:7811:9754
<       b1      18:45192769     63S35M2S        0
```
_log_
```
Read: K00121:54:HC373BBXX:4:1115:7811:9754 was not complete - r1: None, r2: 0
...
Read: K00121:54:HC373BBXX:4:1115:7811:9754 was not complete - r1: 0, r2: None
```