### PR TITLE
Comparing BAMs w/ pysam

### DIFF
--- a/bam_comparison/bam_util_to_csv.py
+++ b/bam_comparison/bam_util_to_csv.py
@@ -209,11 +209,11 @@ class Read_Info():
         self.refr = refr
         self.read = read
 
-    def get_flag(self):
-        return self.flag
-
     def get_mapq(self):
         return self.score
+
+    def get_flag(self):
+        return self.flag
 
     def get_refr(self):
         return self.refr
@@ -267,7 +267,7 @@ def extract_bam_entries(bam_file, entry_map, type):
             entry_map[read_id] = Entry(read_id)
         entry = entry_map[read_id]
 
-        ri_entry = Read_Info(flag, score, refr, read_id)
+        ri_entry = Read_Info(score, flag, refr, read_id)
         if type == CONTROL_BAM:
             entry.add_v1(ri_entry)
         elif type == TARGET_BAM:

--- a/bam_comparison/bam_util_to_csv.py
+++ b/bam_comparison/bam_util_to_csv.py
@@ -12,22 +12,25 @@ class Entry:
         self.read = read
 
     def set_v1(self, v1):
-        if self.v1:
-            print("Read %s has at least two reads for v1: %s" % (read, self.v1))
-            sys.exit(1)
         if not v1.isdigit():
-            print("Read %s v1 not numeric: %s" % (read, v1))
+            print("Read %s v1 not numeric: %s" % (self.read, v1))
             sys.exit(1)
-        self.v1 = int(v1)
+        int_v1 = int(v1)
+        if self.v1 and int_v1 != self.v1:
+            print("Read %s has more than two reads for v2 with different scores: first - %s, update - %s" % (self.read, self.v1, int_v1))
+            sys.exit(1)
+        self.v1 = int_v1
 
     def set_v2(self, v2):
-        if self.v2:
-            print("Read %s has at least two reads for v2: %s" % (read, self.v2))
-            sys.exit(1)
         if not v2.isdigit():
-            print("Read %s v2 not numeric: %s" % (read, v2))
+            print("Read %s v2 not numeric: %s" % (self.read, v2))
             sys.exit(1)
-        self.v2 = int(v2)
+        int_v2 = int(v2)
+        if self.v2 and int_v2 != self.v2:
+            print("Read %s has more than two reads for v2 with different scores: first - %s, update - %s" % (self.read, self.v2, int_v2))
+            sys.exit(1)
+        self.v2 = int_v2
+
     def is_complete(self):
         return self.v2 != None and self.v1 != None
     def to_string(self):
@@ -70,6 +73,7 @@ def parse_entries(bam_util_output):
                 entry = entry_map[curr_read_id]
             else:
                 entry = Entry(curr_read_id)
+                entry_map[curr_read_id] = entry
         else:
             score = line.split()[-1]
             if lead_char == "<":

--- a/bam_comparison/bam_util_to_csv.py
+++ b/bam_comparison/bam_util_to_csv.py
@@ -256,7 +256,7 @@ def write_file(file_name, entry_list):
 
 def extract_bam_entries(bam_file, entry_map, type):
     samfile = pysam.AlignmentFile(bam_file, "rb")
-    aln_segments = samfile.fetch('1')
+    aln_segments = samfile.fetch()
     for aln_seg in aln_segments:
         read_id = aln_seg.query_name
         flag = aln_seg.flag

--- a/bam_comparison/bam_util_to_csv.py
+++ b/bam_comparison/bam_util_to_csv.py
@@ -3,6 +3,9 @@
 import sys
 import os
 USAGE="python bam_util_to_csv.py /PATH/TO/bam_util_output"
+
+ERRORS = []
+
 class Entry:
     read = None
     v1 = None
@@ -17,8 +20,8 @@ class Entry:
             sys.exit(1)
         int_v1 = int(v1)
         if self.v1 and int_v1 != self.v1:
-            print("Read %s has more than two reads for v2 with different scores: first - %s, update - %s" % (self.read, self.v1, int_v1))
-            sys.exit(1)
+            err = "Read %s has more than two reads for v2 with different scores: first - %s, update - %s" % (self.read, self.v1, int_v1)
+            ERRORS.append(err)
         self.v1 = int_v1
 
     def set_v2(self, v2):
@@ -27,8 +30,8 @@ class Entry:
             sys.exit(1)
         int_v2 = int(v2)
         if self.v2 and int_v2 != self.v2:
-            print("Read %s has more than two reads for v2 with different scores: first - %s, update - %s" % (self.read, self.v2, int_v2))
-            sys.exit(1)
+            err = "Read %s has more than two reads for v2 with different scores: first - %s, update - %s" % (self.read, self.v2, int_v2)
+            ERRORS.append(err)
         self.v2 = int_v2
 
     def is_complete(self):
@@ -76,6 +79,7 @@ def parse_entries(bam_util_output):
                 entry_map[curr_read_id] = entry
         else:
             score = line.split()[-1]
+            flag = line.split()[1]
             if lead_char == "<":
                 entry.set_v1(score)
             elif lead_char == ">":
@@ -117,6 +121,8 @@ def main():
     entries = parse_entries(bam_util_output)
     print("WRITING %s" % output_file)
     write_file(output_file, entries)
+    print("ERRORS")
+    print("\n".join(ERRORS))
 
 if __name__ == '__main__':
     main()

--- a/bam_comparison/bam_util_to_csv.py
+++ b/bam_comparison/bam_util_to_csv.py
@@ -132,33 +132,23 @@ class Entry:
         if len(rc_v1_vals) > 0 or len(rc_v2_vals) > 0:
             total_missing_reads += (len(rc_v2_vals) + len(rc_v1_vals))
             ERRORS.append("UNPAIRED [RC]: V1=[{}] V2=[{}]".format(
-                ",".join([f[0] + ":" + str(f[1]) for f in rc_v1_vals]),
-                ",".join([f[0] + ":" + str(f[1]) for f in rc_v2_vals])
+                ",".join([str(f[0]) + ":" + str(f[1]) for f in rc_v1_vals]),
+                ",".join([str(f[0]) + ":" + str(f[1]) for f in rc_v2_vals])
             ))
         if len(fw_v1_vals) > 0 or len(fw_v2_vals) > 0:
             total_missing_reads += (len(fw_v1_vals) + len(fw_v2_vals))
             ERRORS.append("UNPAIRED [FW]: V1=[{}] V2=[{}]".format(
-                ",".join([f[0] + ":" + str(f[1]) for f in fw_v1_vals]),
-                ",".join([f[0] + ":" + str(f[1]) for f in fw_v2_vals])
+                ",".join([str(f[0]) + ":" + str(f[1]) for f in fw_v1_vals]),
+                ",".join([str(f[0]) + ":" + str(f[1]) for f in fw_v2_vals])
             ))
         return pairs
 
 def is_flag_reverse_complemented(flag):
-    if not flag.isdigit():
-        # hex-representation to int
-        flag = int(flag, 16)
-    else:
-        flag = int(flag)
     # 5th bit indicates reverse complement
     fifth_bit = get_kth_bit(flag, 5)
     return fifth_bit == 1
 
 def is_flag_duplicate(flag):
-    if not flag.isdigit():
-        # hex-representation to int
-        flag = int(flag, 16)
-    else:
-        flag = int(flag)
     # 11th bit indicates a duplicate
     eleventh_bit = get_kth_bit(flag, 11)
     return eleventh_bit == 1
@@ -247,7 +237,7 @@ def main():
     b1 = inputs[0]
     b2 = inputs[1]
 
-    basename = "{}____{}".format(b1.split(".")[0], b2.split(".")[0])
+    basename = "{}____{}".format(b1.split("/")[-1].split(".")[0], b2.split("/")[-1].split(".")[0])
     output_file = "{}___bam_differences.csv".format(basename)
 
     print("%s=%s\n%s=%s\nOUTPUT=%s" % (CONTROL_BAM, b1, TARGET_BAM, b2, output_file))

--- a/bam_comparison/bam_util_to_csv.py
+++ b/bam_comparison/bam_util_to_csv.py
@@ -126,15 +126,19 @@ class Entry:
 
         if len(rc_v1_vals) > 0 or len(rc_v2_vals) > 0:
             total_missing_reads += (len(rc_v2_vals) + len(rc_v1_vals))
-            ERRORS.append("UNPAIRED_RC,{},{},{}".format(
+            t_or_c = CONTROL_BAM if len(rc_v1_vals) > 0 else TARGET_BAM
+            ERRORS.append("UNPAIRED_RC,{},{},{},{}".format(
                 self.read,
+                t_or_c,
                 ",".join([str(f[0]) + ":" + str(f[1]) for f in rc_v1_vals]),
                 ",".join([str(f[0]) + ":" + str(f[1]) for f in rc_v2_vals])
             ))
         if len(fw_v1_vals) > 0 or len(fw_v2_vals) > 0:
             total_missing_reads += (len(fw_v1_vals) + len(fw_v2_vals))
-            ERRORS.append("UNPAIRED_FW,{},{},{}".format(
+            t_or_c = CONTROL_BAM if len(fw_v1_vals) > 0 else TARGET_BAM
+            ERRORS.append("UNPAIRED_FW,{},{},{},{}".format(
                 self.read,
+                t_or_c,
                 ",".join([str(f[0]) + ":" + str(f[1]) for f in fw_v1_vals]),
                 ",".join([str(f[0]) + ":" + str(f[1]) for f in fw_v2_vals])
             ))

--- a/bam_comparison/requirements.txt
+++ b/bam_comparison/requirements.txt
@@ -1,3 +1,4 @@
 pandas
 matplotlib
 numpy
+pysam


### PR DESCRIPTION
**Description**: Switching from `bam diff` to `pysam` to extract read id, flag, and MAPQ score and then scripting to do the comparison. This is because `bam diff` doesn't account for reads mapped to different scaffolds or that are too far apart and only outputs a fraction of the reads.

Issues with `bam diff`:
1. The `bam diff` output doesn't output all entries for a `READ_ID` + `FLAG`  at once. This previously caused a READ ID to not be paired when its "partner entry" existed later in the file (example below). `bam util` only holds a certain number of reads in memory while looking for mates - this is limited to a window of default 100,000 bases where same read IDs that have been mapped farther apart than this from each other will be considered "un-paired", REF: [bam diff docs](https://genome.sph.umich.edu/wiki/BamUtil:_diff). This is modifiable via the `--posDiff` option, but this won't account for reads that have been mapped to different chromosomes (which could happen if we are testing alt-aware alignment).
2. I have also noticed that very few read IDs are output when using `bam diff`, e.g. `bam diff --in1 b1_sorted.bam --in2 b2_sorted.bam --mapQual` will return a small fraction of reads. Opened an issue at `https://github.com/statgen/bamUtil/issues/66`

_bam diff output_
```
K00121:54:HC373BBXX:4:1115:7811:9754
>       b1      1:8143070       68S30M2S        0
...
K00121:54:HC373BBXX:4:1115:7811:9754
<       b1      18:45192769     63S35M2S        0
```
_Old Log (not linked)_
```
Read: K00121:54:HC373BBXX:4:1115:7811:9754 was not complete - r1: None, r2: 0
...
Read: K00121:54:HC373BBXX:4:1115:7811:9754 was not complete - r1: 0, r2: None
```